### PR TITLE
Rename Transition -> SceneTransition

### DIFF
--- a/Example/Sample1/Scenes/Sample1A/Sample1AScene.swift
+++ b/Example/Sample1/Scenes/Sample1A/Sample1AScene.swift
@@ -27,7 +27,7 @@ extension Sample1AViewController: Scene, SceneLinkage {
     }
     
 
-    func guide(to destination: Sample1Destination) -> Transition<UIViewController>? {
+    func guide(to destination: Sample1Destination) -> SceneTransition<UIViewController>? {
 
         switch destination {
         case .a:

--- a/Example/Sample1/Scenes/Sample1B/Sample1BScene.swift
+++ b/Example/Sample1/Scenes/Sample1B/Sample1BScene.swift
@@ -22,7 +22,7 @@ extension Sample1BViewController : ActionScene, SceneLinkage {
     
     typealias ContextType = Void
     
-    func guide(to destination: Sample2Destination) -> Transition<UIViewController>? {
+    func guide(to destination: Sample2Destination) -> SceneTransition<UIViewController>? {
         
         switch destination {
         case .a:

--- a/KabuKit.xcodeproj/project.pbxproj
+++ b/KabuKit.xcodeproj/project.pbxproj
@@ -30,7 +30,7 @@
 		4ED7E5A11E2578DF0072CEE9 /* Producer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED7E5A01E2578DF0072CEE9 /* Producer.swift */; };
 		4ED7E5A31E2579EB0072CEE9 /* Scenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED7E5A21E2579EB0072CEE9 /* Scenario.swift */; };
 		4ED7E5A51E259A530072CEE9 /* Director.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED7E5A41E259A530072CEE9 /* Director.swift */; };
-		4ED7E5A91E25A1AB0072CEE9 /* Transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED7E5A81E25A1AB0072CEE9 /* Transition.swift */; };
+		4ED7E5A91E25A1AB0072CEE9 /* SceneTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED7E5A81E25A1AB0072CEE9 /* SceneTransition.swift */; };
 		4ED7E5AC1E2761120072CEE9 /* ActionScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0941FA1E24E84600FBAF21 /* ActionScene.swift */; };
 		4ED7E5AD1E2761120072CEE9 /* ActionActivator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0941FC1E24EF3000FBAF21 /* ActionActivator.swift */; };
 		4ED7E5AE1E2761120072CEE9 /* Observable+KabuKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED7E5941E25559C0072CEE9 /* Observable+KabuKit.swift */; };
@@ -39,7 +39,7 @@
 		4ED7E5B11E2761120072CEE9 /* RecoverPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED7E59A1E2562840072CEE9 /* RecoverPattern.swift */; };
 		4ED7E5B21E2761120072CEE9 /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED7E59C1E25631F0072CEE9 /* Action.swift */; };
 		4ED7E5B31E2762650072CEE9 /* Scene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0941DC1E24187100FBAF21 /* Scene.swift */; };
-		4ED7E5B41E2762650072CEE9 /* Transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED7E5A81E25A1AB0072CEE9 /* Transition.swift */; };
+		4ED7E5B41E2762650072CEE9 /* SceneTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED7E5A81E25A1AB0072CEE9 /* SceneTransition.swift */; };
 		4ED7E5B51E2762650072CEE9 /* Director.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED7E5A41E259A530072CEE9 /* Director.swift */; };
 		4ED7E5B61E2762650072CEE9 /* SceneSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0941E41E241BB100FBAF21 /* SceneSequence.swift */; };
 		4ED7E5B71E2762650072CEE9 /* Producer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED7E5A01E2578DF0072CEE9 /* Producer.swift */; };
@@ -91,7 +91,7 @@
 		4ED7E5A01E2578DF0072CEE9 /* Producer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Producer.swift; sourceTree = "<group>"; };
 		4ED7E5A21E2579EB0072CEE9 /* Scenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Scenario.swift; sourceTree = "<group>"; };
 		4ED7E5A41E259A530072CEE9 /* Director.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Director.swift; sourceTree = "<group>"; };
-		4ED7E5A81E25A1AB0072CEE9 /* Transition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Transition.swift; sourceTree = "<group>"; };
+		4ED7E5A81E25A1AB0072CEE9 /* SceneTransition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SceneTransition.swift; sourceTree = "<group>"; };
 		4EF5CCE61DE30A0C00683D1E /* KabuKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KabuKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4EF5CCE91DE30A0C00683D1E /* KabuKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KabuKit.h; sourceTree = "<group>"; };
 		4EF5CCEA1DE30A0C00683D1E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -274,7 +274,7 @@
 			children = (
 				4EF5CD3B1DE30E3200683D1E /* Rx */,
 				4E0941DC1E24187100FBAF21 /* Scene.swift */,
-				4ED7E5A81E25A1AB0072CEE9 /* Transition.swift */,
+				4ED7E5A81E25A1AB0072CEE9 /* SceneTransition.swift */,
 				4ED7E5A41E259A530072CEE9 /* Director.swift */,
 				4E0941E41E241BB100FBAF21 /* SceneSequence.swift */,
 				4ED7E5A01E2578DF0072CEE9 /* Producer.swift */,
@@ -581,7 +581,7 @@
 				4E0941FD1E24EF3000FBAF21 /* ActionActivator.swift in Sources */,
 				4ED7E5971E2556870072CEE9 /* SubscribeTarget.swift in Sources */,
 				4ED7E5951E25559C0072CEE9 /* Observable+KabuKit.swift in Sources */,
-				4ED7E5A91E25A1AB0072CEE9 /* Transition.swift in Sources */,
+				4ED7E5A91E25A1AB0072CEE9 /* SceneTransition.swift in Sources */,
 				4E0941E11E241AED00FBAF21 /* SceneManager.swift in Sources */,
 				4ED7E5A51E259A530072CEE9 /* Director.swift in Sources */,
 				4ED7E59B1E2562840072CEE9 /* RecoverPattern.swift in Sources */,
@@ -613,7 +613,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4ED7E5B41E2762650072CEE9 /* Transition.swift in Sources */,
+				4ED7E5B41E2762650072CEE9 /* SceneTransition.swift in Sources */,
 				4ED7E5AC1E2761120072CEE9 /* ActionScene.swift in Sources */,
 				4ED7E5B81E2762650072CEE9 /* Scenario.swift in Sources */,
 				4ED7E5AF1E2761120072CEE9 /* SubscribeTarget.swift in Sources */,

--- a/KabuKit/Classes/core/Swift/Director.swift
+++ b/KabuKit/Classes/core/Swift/Director.swift
@@ -10,7 +10,7 @@ public class Director<DestinationType: Destination> {
     
     private weak var sequence: SceneSequence<StageType>?
     
-    private var routing: (DestinationType) -> Transition<DestinationType.StageType>?
+    private var routing: (DestinationType) -> SceneTransition<DestinationType.StageType>?
     
     private var remove: (SceneSequence<StageType>?) -> Void
     
@@ -28,7 +28,7 @@ public class Director<DestinationType: Destination> {
     }
     
     internal init<S: Scene>(scene: S, sequence: SceneSequence<StageType>) where S.RouterType.DestinationType == DestinationType {
-        self.routing = { (destination: DestinationType) -> Transition<DestinationType.StageType>? in
+        self.routing = { (destination: DestinationType) -> SceneTransition<DestinationType.StageType>? in
             
             return scene.router.connect(from: scene, to: destination)
         }

--- a/KabuKit/Classes/core/Swift/Scene.swift
+++ b/KabuKit/Classes/core/Swift/Scene.swift
@@ -76,12 +76,12 @@ public protocol SceneRouter {
     
     associatedtype DestinationType: Destination
     
-    func connect<S: Scene>(from scene: S, to destination: DestinationType) -> Transition<DestinationType.StageType>?
+    func connect<S: Scene>(from scene: S, to destination: DestinationType) -> SceneTransition<DestinationType.StageType>?
 }
 
 public protocol SceneLinkage : SceneRouter {
     
-    func guide(to destination: DestinationType) -> Transition<DestinationType.StageType>?
+    func guide(to destination: DestinationType) -> SceneTransition<DestinationType.StageType>?
 }
 
 public extension SceneLinkage where Self: Scene, Self == Self.RouterType {
@@ -90,7 +90,7 @@ public extension SceneLinkage where Self: Scene, Self == Self.RouterType {
         return self
     }
     
-    final func connect<S: Scene>(from scene: S, to destination: DestinationType) -> Transition<DestinationType.StageType>? {
+    final func connect<S: Scene>(from scene: S, to destination: DestinationType) -> SceneTransition<DestinationType.StageType>? {
         return guide(to: destination)
     }
     
@@ -102,7 +102,7 @@ public protocol Destination {
     
     func specify<S: Scene>(_ newScene: S,
                            _ context: S.ContextType?,
-                           _ atLast: @escaping (StageType, S) -> Void) -> Transition<StageType>? where StageType == S.RouterType.DestinationType.StageType
+                           _ atLast: @escaping (StageType, S) -> Void) -> SceneTransition<StageType>? where StageType == S.RouterType.DestinationType.StageType
     
 }
 
@@ -110,7 +110,7 @@ public extension Destination {
     
     final func specify<S: Scene>(_ newScene: S,
                                  _ context: S.ContextType?,
-                                 _ atLast: @escaping (StageType, S) -> Void) -> Transition<StageType>? where StageType == S.RouterType.DestinationType.StageType {
-        return Transition(newScene, context, atLast)
+                                 _ atLast: @escaping (StageType, S) -> Void) -> SceneTransition<StageType>? where StageType == S.RouterType.DestinationType.StageType {
+        return SceneTransition(newScene, context, atLast)
     }
 }

--- a/KabuKit/Classes/core/Swift/SceneSequence.swift
+++ b/KabuKit/Classes/core/Swift/SceneSequence.swift
@@ -54,7 +54,7 @@ public class SceneSequence<StageType: AnyObject> {
      このメソッドを呼ぶ前にSceneを呼ぶとdirectorはnil
      
      */
-    public func push(transition: Transition<StageType>) {
+    public func push(transition: SceneTransition<StageType>) {
         activateScene(stage, transition.scene, transition.args, transition.execution)
     }
     

--- a/KabuKit/Classes/core/Swift/SceneTransition.swift
+++ b/KabuKit/Classes/core/Swift/SceneTransition.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public struct Transition<StageType: AnyObject> {
+public struct SceneTransition<StageType: AnyObject> {
 
     internal let execution: (_ stage: StageType, _ scene: SceneBase) -> Void
     

--- a/KabuKitTests/Classes/core/Swift/DirectorSpec.swift
+++ b/KabuKitTests/Classes/core/Swift/DirectorSpec.swift
@@ -23,7 +23,7 @@ class DirectorSpec: QuickSpec {
             return true
         }
         
-        func guide(to destination: DestinationType) -> Transition<DestinationType.StageType>? {
+        func guide(to destination: DestinationType) -> SceneTransition<DestinationType.StageType>? {
             return destination.specify(DirectorSpecScene(), nil) { (stage, scene) in
                 self.isTransit = true
             }
@@ -47,7 +47,7 @@ class DirectorSpec: QuickSpec {
             return true
         }
         
-        func guide(to destination: DestinationType) -> Transition<DestinationType.StageType>? {
+        func guide(to destination: DestinationType) -> SceneTransition<DestinationType.StageType>? {
             return destination.specify(DirectorSpecScene(), nil) { (stage, scene) in
                 self.isTransit = true
             }

--- a/KabuKitTests/Classes/core/Swift/MockRouter.swift
+++ b/KabuKitTests/Classes/core/Swift/MockRouter.swift
@@ -8,7 +8,7 @@ import KabuKit
 class MockRouter: SceneRouter {
     typealias DestinationType = MockDestination
     
-    func connect<S : Scene>(from scene: S, to destination: MockDestination) -> Transition<NSObject>? {
+    func connect<S : Scene>(from scene: S, to destination: MockDestination) -> SceneTransition<NSObject>? {
         return nil
     }
 }

--- a/KabuKitTests/Classes/core/Swift/SceneLinkageSpec.swift
+++ b/KabuKitTests/Classes/core/Swift/SceneLinkageSpec.swift
@@ -24,7 +24,7 @@ class SceneLinkageSpec: QuickSpec {
             return false
         }
         
-        func guide(to: MockDestination) -> Transition<NSObject>? {
+        func guide(to: MockDestination) -> SceneTransition<NSObject>? {
             return nil
         }
         

--- a/KabuKitTests/Classes/core/Swift/SceneManagerSpec.swift
+++ b/KabuKitTests/Classes/core/Swift/SceneManagerSpec.swift
@@ -26,7 +26,7 @@ class SceneManagerSpec: QuickSpec {
             return true
         }
         
-        func guide(to destination: DestinationType) -> Transition<DestinationType.StageType>? {
+        func guide(to destination: DestinationType) -> SceneTransition<DestinationType.StageType>? {
             return destination.specify(MockScene(), nil) { (stage, scene) in
                 self.isTransit = true
             }

--- a/KabuKitTests/Classes/core/Swift/SceneRequestSpec.swift
+++ b/KabuKitTests/Classes/core/Swift/SceneRequestSpec.swift
@@ -33,9 +33,9 @@ class SceneRequestSpec: QuickSpec {
         
         
         
-        describe("Transition生成について") {
+        describe("SceneTransition生成について") {
 
-            it("specifyを呼ぶとTransitionを生成することができる") {
+            it("specifyを呼ぶとSceneTransitionを生成することができる") {
                 var isCalled = false
                 let request = MockDestination()
                 let scene = SceneRequestScene()

--- a/KabuKitTests/Classes/core/Swift/SceneSequenceSpec.swift
+++ b/KabuKitTests/Classes/core/Swift/SceneSequenceSpec.swift
@@ -81,7 +81,7 @@ class SceneSequenceSpec: QuickSpec {
                 sequence.start(producer: nil)
                 let secondScene = SequenceSpecScene1()
                 var isCalled = false
-                let transition = Transition(secondScene, nil) { (stage, scene) in
+                let transition = SceneTransition(secondScene, nil) { (stage, scene) in
                     isCalled = true
                 }
 
@@ -121,7 +121,7 @@ class SceneSequenceSpec: QuickSpec {
                 
                 let sequence = SceneSequence(NSObject(), firstScene, nil){ (stage, scene) in }
 
-                let transition = Transition(secondScene, nil) { (stage, scene) in }
+                let transition = SceneTransition(secondScene, nil) { (stage, scene) in }
                 sequence.start(producer: nil)
                 sequence.push(transition: transition)
                 
@@ -142,7 +142,7 @@ class SceneSequenceSpec: QuickSpec {
                 let secondScene = SequenceSpecScene1()
                 
                 let sequence = SceneSequence(NSObject(), firstScene, nil){ (stage, scene) in }
-                let transition = Transition(secondScene, nil) { (stage, scene) in }
+                let transition = SceneTransition(secondScene, nil) { (stage, scene) in }
                 sequence.start(producer: nil)
                 sequence.push(transition: transition)
                 expect(firstScene.isRemoved).to(beFalse())


### PR DESCRIPTION
- `Transition` is commonly used on UIViewController, so it makes confusing