### PR TITLE
Arrange schemes for Tests and Carthage

### DIFF
--- a/KabuKit.xcodeproj/xcshareddata/xcschemes/KabuKitTests.xcscheme
+++ b/KabuKit.xcodeproj/xcshareddata/xcschemes/KabuKitTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -9,42 +9,14 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0F9289273B347440A4AD60497B2B4A1B"
-               BuildableName = "Pods_KabuKit.framework"
-               BlueprintName = "Pods-KabuKit"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A2E19347D12CD916835609FEC00D771C"
-               BuildableName = "Pods_KabuKitTests.framework"
-               BlueprintName = "Pods-KabuKitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "4EF5CCE51DE30A0C00683D1E"
-               BuildableName = "KabuKit.framework"
-               BlueprintName = "KabuKit"
+               BlueprintIdentifier = "4EF5CCEE1DE30A0C00683D1E"
+               BuildableName = "KabuKitTests.xctest"
+               BlueprintName = "KabuKitTests"
                ReferencedContainer = "container:KabuKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -54,8 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -68,15 +39,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4EF5CCE51DE30A0C00683D1E"
-            BuildableName = "KabuKit.framework"
-            BlueprintName = "KabuKit"
-            ReferencedContainer = "container:KabuKit.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -93,9 +55,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4EF5CCE51DE30A0C00683D1E"
-            BuildableName = "KabuKit.framework"
-            BlueprintName = "KabuKit"
+            BlueprintIdentifier = "4EF5CCEE1DE30A0C00683D1E"
+            BuildableName = "KabuKitTests.xctest"
+            BlueprintName = "KabuKitTests"
             ReferencedContainer = "container:KabuKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -111,9 +73,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4EF5CCE51DE30A0C00683D1E"
-            BuildableName = "KabuKit.framework"
-            BlueprintName = "KabuKit"
+            BlueprintIdentifier = "4EF5CCEE1DE30A0C00683D1E"
+            BuildableName = "KabuKitTests.xctest"
+            BlueprintName = "KabuKitTests"
             ReferencedContainer = "container:KabuKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,7 +10,7 @@ platform :ios do
   desc "Runs tests as iOS"
   lane :test do
     scan(
-         scheme: "KabuKit",
+         scheme: "KabuKitTests",
          devices: ["iPhone 6s"],
          clean: true,
          sdk: "iphonesimulator",


### PR DESCRIPTION
fix #38

Multiple shared schemes are no good for Carthage.
So I arranged

- `KabuKit` scheme **NOT SHARED** (for CocoaPods)
- `KabuKit-iOS` scheme **SHARED** (for Carthage)
- `KabuKitTests` scheme **SHARED** (for CocoaPods)

![2017-01-16 16 33 55](https://cloud.githubusercontent.com/assets/3917725/21975516/66be27b6-dc10-11e6-8341-f5462c461e9e.png)