### PR TITLE
Make `startSequence(sequence:)` and `activate(action:)` result discardable

### DIFF
--- a/Example/Sample1/Scenes/Sample1B/Sample1BScene.swift
+++ b/Example/Sample1/Scenes/Sample1B/Sample1BScene.swift
@@ -48,7 +48,7 @@ extension Sample1BViewController : ActionScene, SceneLinkage {
     override func viewDidLoad() {
         self.navigationItem.hidesBackButton = true
         let action = Sample1BAction(label: label, buttonA: nextButtonA, buttonB: nextButtonB, prevButton: prevButton)
-        _ = activator?.activate(action: action)
+        activator?.activate(action: action)
     }
     
     

--- a/Example/Sample2/Sample2Scenario.swift
+++ b/Example/Sample2/Sample2Scenario.swift
@@ -66,7 +66,7 @@ import UIKit
             scene.view.frame = stage.view.frame
         }
         
-        _ = producer.startSequence(sequence: loginSequence!)
+        producer.startSequence(sequence: loginSequence!)
     }
     
     func describe<E, S>(_ event: E, from sequence: SceneSequence<S>, through producer: Producer?) {
@@ -75,8 +75,8 @@ import UIKit
             if (eve == "start") {
                 root.addChildViewController(tabBarController)
                 root.view.addSubview(tabBarController.view)
-                _ = producer?.startSequence(sequence: aSequence!)
-                _ = producer?.startSequence(sequence: bSequence!)
+                producer?.startSequence(sequence: aSequence!)
+                producer?.startSequence(sequence: bSequence!)
             }
         }
     }

--- a/Example/Sample2/Scenes/Sample2/Sample2Scene.swift
+++ b/Example/Sample2/Scenes/Sample2/Sample2Scene.swift
@@ -29,7 +29,7 @@ extension Sample2ViewController : ActionScene, SceneLinkage {
     
     override func viewDidLoad() {
         let action = Sample2Action(startButton: startButton)
-        _ = activator?.activate(action: action)
+        activator?.activate(action: action)
     }
     
 

--- a/Example/Sample2/Scenes/Sample2A/Sample2AScene.swift
+++ b/Example/Sample2/Scenes/Sample2A/Sample2AScene.swift
@@ -61,7 +61,7 @@ extension Sample2AViewController: ActionScene, SceneLinkage {
         }
 
         let action = Sample2AAction(nextButtonA: nextButtonA, nextButtonB: nextButtonB, prevButton: prevButton)
-        _ = activator?.activate(action: action)
+        activator?.activate(action: action)
     }
 
 }

--- a/Example/Sample2/Scenes/Sample2B/Sample2BScene.swift
+++ b/Example/Sample2/Scenes/Sample2B/Sample2BScene.swift
@@ -57,7 +57,7 @@ extension Sample2BViewController: ActionScene, SceneLinkage {
             self.prevButton.isEnabled = false
             self.prevButton.alpha = 0.5
         }
-        _ = activator?.activate(action: action)
+        activator?.activate(action: action)
     }
 
     

--- a/KabuKit/Classes/core/Swift/Producer.swift
+++ b/KabuKit/Classes/core/Swift/Producer.swift
@@ -27,6 +27,7 @@ public class Producer {
      
      すでにスタート済みだった場合はfalseを返します
      */
+    @discardableResult
     public func startSequence<S>(sequence: SceneSequence<S>) -> Bool {
         return sequence.start(producer: self)
     }
@@ -38,7 +39,7 @@ public class Producer {
      */
     public static func run<S: AnyObject>(sequence: SceneSequence<S>) -> Producer {
         let producer = Producer(sequence: sequence)
-        _ = producer.startSequence(sequence: sequence)
+        producer.startSequence(sequence: sequence)
 
         return producer
     }

--- a/KabuKit/Classes/core/Swift/Rx/ActionActivator.swift
+++ b/KabuKit/Classes/core/Swift/Rx/ActionActivator.swift
@@ -36,6 +36,7 @@ public class ActionActivator<DestinationType: Destination> {
                 すでにactivate済みのインスタンスがactionに指定された場合は何もされないため
                 falseを返します
      */
+    @discardableResult
     public func activate<A: Action>(action: A, onStart: () -> Void = {}) -> Bool where A.DestinationType == DestinationType {
         let typeName = String(describing: type(of: action))
         
@@ -61,7 +62,7 @@ public class ActionActivator<DestinationType: Destination> {
      再度activateされるまでイベントを飛ばすことはありません
      
      */
-    public func deactivate<A: Action>(actionType: A.Type) -> Bool where A.DestinationType == DestinationType{
+    public func deactivate<A: Action>(actionType: A.Type) -> Bool where A.DestinationType == DestinationType {
         // 指定のクラス名に紐づくDisposableを取得し
         // 全て破棄し、DisposableMapも空にする
         let typeName = String(describing: actionType)
@@ -97,7 +98,7 @@ public class ActionActivator<DestinationType: Destination> {
      - parameters: 
        - actionType: Actionの型
      */
-    public func resolve<A: Action>(actionType: A.Type) -> A? where A.SceneType.RouterType.DestinationType == DestinationType{
+    public func resolve<A: Action>(actionType: A.Type) -> A? where A.SceneType.RouterType.DestinationType == DestinationType {
         let typeName = String(describing: actionType)
 
         return actionTypeHashMap?[typeName] as? A


### PR DESCRIPTION
https://github.com/apple/swift-evolution/blob/master/proposals/0047-nonvoid-warn.md