### PR TITLE
:name_badge: Rename `Transition` to `Procedure` [#65]

### DIFF
--- a/KabuKit.xcodeproj/project.pbxproj
+++ b/KabuKit.xcodeproj/project.pbxproj
@@ -20,7 +20,7 @@
 		4EC432F61EED720C00FF4145 /* SceneOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC432F51EED720C00FF4145 /* SceneOperation.swift */; };
 		4EC4333E1EEF14AF00FF4145 /* ScenarioTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC4333D1EEF14AF00FF4145 /* ScenarioTest.swift */; };
 		4EC433421EEFFAA100FF4145 /* Guide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC433411EEFFAA000FF4145 /* Guide.swift */; };
-		4EC433441EF012C400FF4145 /* Transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC433431EF012C400FF4145 /* Transition.swift */; };
+		4EC433441EF012C400FF4145 /* TransitionProcedure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC433431EF012C400FF4145 /* TransitionProcedure.swift */; };
 		4EC4335B1EF06F5B00FF4145 /* OperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC4335A1EF06F5B00FF4145 /* OperationTest.swift */; };
 		4ED3FEA81ED597FC004BC048 /* KabuKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4ED3FE9E1ED597FC004BC048 /* KabuKit.framework */; };
 		4ED3FEAD1ED597FC004BC048 /* KabuKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED3FEAC1ED597FC004BC048 /* KabuKitTests.swift */; };
@@ -63,7 +63,7 @@
 		4EC432F51EED720C00FF4145 /* SceneOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SceneOperation.swift; sourceTree = "<group>"; };
 		4EC4333D1EEF14AF00FF4145 /* ScenarioTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScenarioTest.swift; sourceTree = "<group>"; };
 		4EC433411EEFFAA000FF4145 /* Guide.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Guide.swift; sourceTree = "<group>"; };
-		4EC433431EF012C400FF4145 /* Transition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Transition.swift; sourceTree = "<group>"; };
+		4EC433431EF012C400FF4145 /* TransitionProcedure.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionProcedure.swift; sourceTree = "<group>"; };
 		4EC4335A1EF06F5B00FF4145 /* OperationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperationTest.swift; sourceTree = "<group>"; };
 		4ED3FE9E1ED597FC004BC048 /* KabuKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KabuKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4ED3FEA11ED597FC004BC048 /* KabuKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KabuKit.h; sourceTree = "<group>"; };
@@ -201,7 +201,7 @@
 				4ED3FEC41ED5989E004BC048 /* SceneSequence.swift */,
 				4EC432F51EED720C00FF4145 /* SceneOperation.swift */,
 				4EC433411EEFFAA000FF4145 /* Guide.swift */,
-				4EC433431EF012C400FF4145 /* Transition.swift */,
+				4EC433431EF012C400FF4145 /* TransitionProcedure.swift */,
 			);
 			path = Swift;
 			sourceTree = "<group>";
@@ -390,7 +390,7 @@
 				4ED3FED21ED5989E004BC048 /* Director.swift in Sources */,
 				4EC432F61EED720C00FF4145 /* SceneOperation.swift in Sources */,
 				4ED3FED41ED5989E004BC048 /* Scenario.swift in Sources */,
-				4EC433441EF012C400FF4145 /* Transition.swift in Sources */,
+				4EC433441EF012C400FF4145 /* TransitionProcedure.swift in Sources */,
 				4ED3FED61ED5989E004BC048 /* Scene.swift in Sources */,
 				4ED3FED71ED5989E004BC048 /* SceneSequence.swift in Sources */,
 				4EC433421EEFFAA100FF4145 /* Guide.swift in Sources */,

--- a/KabuKit/Classes/core/Swift/Scenario.swift
+++ b/KabuKit/Classes/core/Swift/Scenario.swift
@@ -7,7 +7,7 @@ import Foundation
  一つのSceneごとにつくられる
  
  */
-public class Scenario<Current: Screen, Stage> : Transition {
+public class Scenario<Current: Screen, Stage> : TransitionProcedure {
     
     internal typealias Transitioning = (Current, Stage, Any?) -> Void
     
@@ -35,7 +35,7 @@ public class Scenario<Current: Screen, Stage> : Transition {
         name = String(reflecting: fromType)
     }
     
-    internal func setup<S>(at: Screen, on stage: S, with: SceneContainer, when rewind: Transition.Rewind?) {
+    internal func setup<S>(at: Screen, on stage: S, with: SceneContainer, when rewind: TransitionProcedure.Rewind?) {
         self.setup(at: at, on: stage, with: with, when: rewind, {})
     }
     

--- a/KabuKit/Classes/core/Swift/SceneOperation.swift
+++ b/KabuKit/Classes/core/Swift/SceneOperation.swift
@@ -10,11 +10,11 @@ import Foundation
  */
 public class SceneOperation<Stage> {
     
-    private var scenedTransition = [String : Transition]()
+    private var scenedTransitionProcedure = [String : TransitionProcedure]()
     
-    private var anyTransition: Transition?
+    private var anyTransitionProcedure: TransitionProcedure?
     
-    private let anyTransitionName: String
+    private let anyTransitionProcedureName: String
 
     /**
      指定したSceneでのScenarioのフローを定義します
@@ -37,7 +37,7 @@ public class SceneOperation<Stage> {
      */
     public func at<From: Scene>(_ fromType: From.Type, _ run: (Scenario<From, Stage>) -> Void) {
         let scenario = Scenario<From, Stage>(fromType)
-        scenedTransition[scenario.name] = scenario
+        scenedTransitionProcedure[scenario.name] = scenario
         run(scenario)
     }
     
@@ -60,27 +60,27 @@ public class SceneOperation<Stage> {
      - Parameters:
        - run: Scenarioを使ったフロー
      */
-    public func atAnyScene(run: (Scenario<AnyTransition, Stage>) -> Void){
-        anyTransition = anyTransition ?? Scenario<AnyTransition, Stage>(AnyTransition.self)
-        guard let scenario = anyTransition as? Scenario<AnyTransition, Stage> else { return }
-        scenedTransition[anyTransitionName] = scenario
+    public func atAnyScene(run: (Scenario<AnyTransitionProcedure, Stage>) -> Void){
+        anyTransitionProcedure = anyTransitionProcedure ?? Scenario<AnyTransitionProcedure, Stage>(AnyTransitionProcedure.self)
+        guard let scenario = anyTransitionProcedure as? Scenario<AnyTransitionProcedure, Stage> else { return }
+        scenedTransitionProcedure[anyTransitionProcedureName] = scenario
         run(scenario)
     }
     
-    internal func resolve(from: Screen) -> Transition? {
+    internal func resolve(from: Screen) -> TransitionProcedure? {
         let name = String(reflecting: type(of: from))
-        return scenedTransition[name]
+        return scenedTransitionProcedure[name]
     }
     
-    internal func resolve() -> Transition? {
-        return scenedTransition[anyTransitionName]
+    internal func resolve() -> TransitionProcedure? {
+        return scenedTransitionProcedure[anyTransitionProcedureName]
     }
 
     internal init() {
-        anyTransitionName = String(reflecting: AnyTransition.self)
+        anyTransitionProcedureName = String(reflecting: AnyTransitionProcedure.self)
     }
 }
 
-public class AnyTransition: Screen {
+public class AnyTransitionProcedure: Screen {
     internal init() {}
 }

--- a/KabuKit/Classes/core/Swift/SceneSequence.swift
+++ b/KabuKit/Classes/core/Swift/SceneSequence.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-internal var transitionByScene = [ScreenHashWrapper : Transition]()
+internal var procedureByScene = [ScreenHashWrapper : TransitionProcedure]()
 
 /**
  複数のSceneを管理し、それぞれからの遷移リクエストを受け付け画面切り替えを行うクラス
@@ -17,7 +17,7 @@ public class SceneSequence<C, G: Guide> : Scene, SceneContainer {
     
     private var scenes: [Screen]
     
-    private var currentTransition: Transition?
+    private var currentTransitionProcedure: TransitionProcedure?
     
     private let isRecordable: Bool
     
@@ -33,7 +33,7 @@ public class SceneSequence<C, G: Guide> : Scene, SceneContainer {
         guard let scenario = operation.resolve(from: screen) else { return }
         let hashwrap = ScreenHashWrapper(screen)
         self.scenes.append(screen)
-        transitionByScene[hashwrap] = scenario
+        procedureByScene[hashwrap] = scenario
         contextByScreen[hashwrap] = context
         scenario.setup(at: screen, on: self.stage!, with: self, when: rewind)
     }
@@ -41,7 +41,7 @@ public class SceneSequence<C, G: Guide> : Scene, SceneContainer {
     internal func remove(screen: Screen, completion: () -> Void) {
         let hashwrap = ScreenHashWrapper(screen)
         _ = self.scenes.popLast()
-        transitionByScene.removeValue(forKey: hashwrap)
+        procedureByScene.removeValue(forKey: hashwrap)
         contextByScreen.removeValue(forKey: hashwrap)
         completion()
     }
@@ -68,7 +68,7 @@ public class SceneSequence<C, G: Guide> : Scene, SceneContainer {
         scenario.setup(at: scene, on: stage, with: self, when: nil) {
             let hashwrap = ScreenHashWrapper(scene)
             self.scenes.append(scene)
-            transitionByScene[hashwrap] = scenario
+            procedureByScene[hashwrap] = scenario
             contextByScreen[hashwrap] = context
             invoke(scene, stage)
         }

--- a/KabuKit/Classes/core/Swift/Screen.swift
+++ b/KabuKit/Classes/core/Swift/Screen.swift
@@ -34,8 +34,8 @@ public protocol Screen : class {
 extension Screen {
 
     
-    internal var transition: Transition? {
-        return transitionByScene[ScreenHashWrapper(self)]
+    internal var TransitionProcedure: TransitionProcedure? {
+        return procedureByScene[ScreenHashWrapper(self)]
     }
     
 
@@ -45,7 +45,7 @@ extension Screen {
     
 
     public func leave(_ completion: @escaping (Bool) -> Void) -> Void {
-        self.transition?.back(completion)
+        self.TransitionProcedure?.back(completion)
     }
 
     public func send<T>(_ request: Request<T>) -> Void {
@@ -54,7 +54,7 @@ extension Screen {
     
     
     public func send<T>(_ request: Request<T>, _ completion: @escaping (Bool) -> Void) -> Void {
-        transition?.start(at: request, completion)
+        TransitionProcedure?.start(at: request, completion)
     }
 
 }

--- a/KabuKit/Classes/core/Swift/TransitionProcedure.swift
+++ b/KabuKit/Classes/core/Swift/TransitionProcedure.swift
@@ -5,18 +5,18 @@
 import Foundation
 
 /**
- 画面遷移を示したプロトコル
+ 画面を切り替える手順を示したプロトコル
 
  */
-protocol Transition {
+protocol TransitionProcedure {
     
     typealias Rewind = () -> Void
    
     /**
-     Trnasitionを実行するために必要なパラメータをセットする
+     TransitionProcedureを実行するために必要なパラメータをセットする
      
      - Parameters:
-       - at: どこの画面のTransitionか指定するため
+       - at: どこの画面のTransitionProcedureか指定するため
        - stage: Transionを行うベースとなるメソッド
        - rewind: 前の画面に戻る為の処理
      */
@@ -25,7 +25,7 @@ protocol Transition {
     func setup<S>(at: Screen, on stage: S, with: SceneContainer, when rewind: Rewind?, _ completion: @escaping () -> Void)
     
     /**
-     Transitionを実行する
+     TransitionProcedureを実行する
      
      - Parameters: 
        - request: aa


### PR DESCRIPTION
**UPDATE**
 - Scenario's protocol is named `Transition`, but scenario does not transition, but handle transtion.
 - So, scenario close to procedure rather than transition
 - `Transition` keyword will be used other class