### PR TITLE
Add rewind call condition argument

### DIFF
--- a/Example/Sample1/Sequence/Scenes/Sample1A/Sample1AScene.swift
+++ b/Example/Sample1/Sequence/Scenes/Sample1A/Sample1AScene.swift
@@ -19,7 +19,11 @@ extension Sample1AViewController: Scene {
     }
     
     func onPressPrevButton(sender: UIButton) {
-        leave()
+        leave(true)
+    }
+
+    func onPressPopButton(sender: UIButton) {
+        self.navigationController?.popViewController(animated: true)
     }
     
     // MARK: - Override
@@ -34,5 +38,12 @@ extension Sample1AViewController: Scene {
         nextButtonA.addTarget(self, action: #selector(onPressAButton(sender:)), for: .touchUpInside)
         nextButtonB.addTarget(self, action: #selector(onPressBButton(sender:)), for: .touchUpInside)
         prevButton.addTarget(self, action: #selector(onPressPrevButton(sender:)), for: .touchUpInside)
+        popButton.addTarget(self, action: #selector(onPressPopButton(sender:)), for: .touchUpInside)
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        if self.isMovingFromParentViewController {
+            leave(false)
+        }
     }
 }

--- a/Example/Sample1/Sequence/Scenes/Sample1A/Sample1AScene.swift
+++ b/Example/Sample1/Sequence/Scenes/Sample1A/Sample1AScene.swift
@@ -19,7 +19,7 @@ extension Sample1AViewController: Scene {
     }
     
     func onPressPrevButton(sender: UIButton) {
-        leave(true)
+        leave()
     }
 
     func onPressPopButton(sender: UIButton) {
@@ -31,9 +31,15 @@ extension Sample1AViewController: Scene {
         if (context == true) {
             prevButton.isEnabled = true
             prevButton.alpha = 1.0
+
+            popButton.isEnabled = true
+            popButton.alpha = 1.0
         } else {
             prevButton.isEnabled = false
             prevButton.alpha = 0.5
+
+            popButton.isEnabled = false
+            popButton.alpha = 0.5
         }
         nextButtonA.addTarget(self, action: #selector(onPressAButton(sender:)), for: .touchUpInside)
         nextButtonB.addTarget(self, action: #selector(onPressBButton(sender:)), for: .touchUpInside)

--- a/Example/Sample1/Sequence/Scenes/Sample1B/Sample1BScene.swift
+++ b/Example/Sample1/Sequence/Scenes/Sample1B/Sample1BScene.swift
@@ -22,7 +22,7 @@ extension Sample1BViewController : Scene {
     }
     
     func onPressPrevButton(sender: UIButton) {
-        leave(true)
+        leave()
     }
     
     // MARK: - Override

--- a/Example/Sample1/Sequence/Scenes/Sample1B/Sample1BScene.swift
+++ b/Example/Sample1/Sequence/Scenes/Sample1B/Sample1BScene.swift
@@ -22,7 +22,7 @@ extension Sample1BViewController : Scene {
     }
     
     func onPressPrevButton(sender: UIButton) {
-        leave()
+        leave(true)
     }
     
     // MARK: - Override

--- a/Example/Sample1/Sequence/ViewControllers/Sample1AViewController.swift
+++ b/Example/Sample1/Sequence/ViewControllers/Sample1AViewController.swift
@@ -18,6 +18,8 @@ class Sample1AViewController: UIViewController {
     
     @IBOutlet weak var prevButton: UIButton!
     
+    @IBOutlet weak var popButton: UIButton!
+
     deinit {
         print("sample1A deinit")
     }

--- a/Example/Sample1/Sequence/ViewControllers/Sample1AViewController.xib
+++ b/Example/Sample1/Sequence/ViewControllers/Sample1AViewController.xib
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -15,6 +15,7 @@
                 <outlet property="label" destination="MZV-rY-bMw" id="okG-Lh-liA"/>
                 <outlet property="nextButtonA" destination="nyj-Z1-M3w" id="sH4-3A-vQ1"/>
                 <outlet property="nextButtonB" destination="rUU-tA-IW2" id="G96-dy-7zP"/>
+                <outlet property="popButton" destination="ZSh-sR-0iD" id="OuG-V2-ylB"/>
                 <outlet property="prevButton" destination="Et3-zF-D6f" id="qtz-h9-ehp"/>
                 <outlet property="view" destination="sfl-i5-ODO" id="M73-2t-zM7"/>
             </connections>
@@ -48,10 +49,18 @@
                         <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </state>
                 </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZSh-sR-0iD">
+                    <rect key="frame" x="0.0" y="318.5" width="375" height="30"/>
+                    <state key="normal" title="pop">
+                        <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </state>
+                </button>
             </subviews>
             <color key="backgroundColor" red="0.0039215686274509803" green="0.35294117647058826" blue="0.23921568627450981" alpha="1" colorSpace="calibratedRGB"/>
             <constraints>
                 <constraint firstItem="MZV-rY-bMw" firstAttribute="centerY" secondItem="sfl-i5-ODO" secondAttribute="centerY" multiplier="0.5" id="0XP-zf-hwm"/>
+                <constraint firstItem="ZSh-sR-0iD" firstAttribute="centerY" secondItem="sfl-i5-ODO" secondAttribute="centerY" id="7WR-vq-3eV"/>
+                <constraint firstItem="ZSh-sR-0iD" firstAttribute="width" secondItem="sfl-i5-ODO" secondAttribute="width" id="Am3-Ad-GYK"/>
                 <constraint firstItem="rUU-tA-IW2" firstAttribute="centerX" secondItem="sfl-i5-ODO" secondAttribute="centerX" id="CIp-zQ-7eK"/>
                 <constraint firstItem="rUU-tA-IW2" firstAttribute="centerY" secondItem="sfl-i5-ODO" secondAttribute="centerY" multiplier="1.5" id="Dt3-QW-MNq"/>
                 <constraint firstItem="Et3-zF-D6f" firstAttribute="centerX" secondItem="sfl-i5-ODO" secondAttribute="centerX" id="RLg-s5-nIP"/>
@@ -59,6 +68,7 @@
                 <constraint firstItem="MZV-rY-bMw" firstAttribute="centerX" secondItem="sfl-i5-ODO" secondAttribute="centerX" id="apN-YX-uPn"/>
                 <constraint firstItem="nyj-Z1-M3w" firstAttribute="centerY" secondItem="sfl-i5-ODO" secondAttribute="centerY" multiplier="1.25" id="olc-dt-5FH"/>
                 <constraint firstItem="Et3-zF-D6f" firstAttribute="centerY" secondItem="sfl-i5-ODO" secondAttribute="centerY" multiplier="1.75" id="s8n-1J-1AI"/>
+                <constraint firstItem="ZSh-sR-0iD" firstAttribute="centerX" secondItem="sfl-i5-ODO" secondAttribute="centerX" id="yhK-f8-MK9"/>
             </constraints>
             <point key="canvasLocation" x="-178" y="38"/>
         </view>

--- a/KabuKit/Classes/core/Swift/Scenario.swift
+++ b/KabuKit/Classes/core/Swift/Scenario.swift
@@ -67,14 +67,14 @@ public class Scenario<Current: Screen, Stage> : TransitionProcedure {
     }
     
     
-    internal func back(_ needsRewind: Bool, _ completion: @escaping (Bool) -> Void) {
+    internal func back(_ runRewindHandler: Bool, _ completion: @escaping (Bool) -> Void) {
         queue.async {
             guard let rewind = self.rewind , let current = self.current else {
                 completion(false)
                 return
             }
             
-            if needsRewind {
+            if runRewindHandler {
                 rewind()
             }
 

--- a/KabuKit/Classes/core/Swift/Scenario.swift
+++ b/KabuKit/Classes/core/Swift/Scenario.swift
@@ -67,14 +67,17 @@ public class Scenario<Current: Screen, Stage> : TransitionProcedure {
     }
     
     
-    internal func back(_ completion: @escaping (Bool) -> Void) {
+    internal func back(_ needsRewind: Bool, _ completion: @escaping (Bool) -> Void) {
         queue.async {
             guard let rewind = self.rewind , let current = self.current else {
                 completion(false)
                 return
             }
             
-            rewind()
+            if needsRewind {
+                rewind()
+            }
+
             self.container?.remove(screen: current) {
                 completion(true)
             }

--- a/KabuKit/Classes/core/Swift/Screen.swift
+++ b/KabuKit/Classes/core/Swift/Screen.swift
@@ -26,9 +26,9 @@ public protocol Screen : class {
      - Attention :
      ただし、前のシーンがない場合は戻らず、何も起きない
      */
-    func leave() -> Void
+    func leave(_ needsRewind: Bool) -> Void
     
-    func leave(_ completion: @escaping (Bool) -> Void) -> Void
+    func leave(_ needsRewind: Bool, _ completion: @escaping (Bool) -> Void) -> Void
 }
 
 extension Screen {
@@ -39,13 +39,13 @@ extension Screen {
     }
     
 
-    public func leave() -> Void {
-        self.leave({ (Bool) in })
+    public func leave(_ needsRewind: Bool) -> Void {
+        self.leave(needsRewind, { (Bool) in })
     }
     
 
-    public func leave(_ completion: @escaping (Bool) -> Void) -> Void {
-        self.TransitionProcedure?.back(completion)
+    public func leave(_ needsRewind: Bool, _ completion: @escaping (Bool) -> Void) -> Void {
+        self.TransitionProcedure?.back(needsRewind, completion)
     }
 
     public func send<T>(_ request: Request<T>) -> Void {

--- a/KabuKit/Classes/core/Swift/Screen.swift
+++ b/KabuKit/Classes/core/Swift/Screen.swift
@@ -26,9 +26,13 @@ public protocol Screen : class {
      - Attention :
      ただし、前のシーンがない場合は戻らず、何も起きない
      */
-    func leave(_ needsRewind: Bool) -> Void
-    
-    func leave(_ needsRewind: Bool, _ completion: @escaping (Bool) -> Void) -> Void
+    func leave() -> Void
+
+    func leave(_ runTransition: Bool) -> Void
+
+    func leave(_ completion: @escaping (Bool) -> Void) -> Void
+
+    func leave(_ runTransition: Bool, _ completion: @escaping (Bool) -> Void) -> Void
 }
 
 extension Screen {
@@ -38,14 +42,20 @@ extension Screen {
         return procedureByScene[ScreenHashWrapper(self)]
     }
     
-
-    public func leave(_ needsRewind: Bool) -> Void {
-        self.leave(needsRewind, { (Bool) in })
+    public func leave() -> Void {
+        self.leave(true)
     }
-    
 
-    public func leave(_ needsRewind: Bool, _ completion: @escaping (Bool) -> Void) -> Void {
-        self.TransitionProcedure?.back(needsRewind, completion)
+    public func leave(_ runTransition: Bool) -> Void {
+        self.leave(runTransition, { (Bool) in })
+    }
+
+    public func leave(_ completion: @escaping (Bool) -> Void) -> Void {
+        self.leave(true, completion)
+    }
+
+    public func leave(_ runTransition: Bool, _ completion: @escaping (Bool) -> Void) -> Void {
+        self.TransitionProcedure?.back(runTransition, completion)
     }
 
     public func send<T>(_ request: Request<T>) -> Void {

--- a/KabuKit/Classes/core/Swift/TransitionProcedure.swift
+++ b/KabuKit/Classes/core/Swift/TransitionProcedure.swift
@@ -40,5 +40,5 @@ protocol TransitionProcedure {
      そのさい、事前に規定されたロジックが呼ばれる
      
      */
-    func back(_ needsRewind: Bool, _ completion: @escaping (Bool) -> Void)
+    func back(_ runRewindHandler: Bool, _ completion: @escaping (Bool) -> Void)
 }

--- a/KabuKit/Classes/core/Swift/TransitionProcedure.swift
+++ b/KabuKit/Classes/core/Swift/TransitionProcedure.swift
@@ -40,5 +40,5 @@ protocol TransitionProcedure {
      そのさい、事前に規定されたロジックが呼ばれる
      
      */
-    func back(_ completion: @escaping (Bool) -> Void)
+    func back(_ needsRewind: Bool, _ completion: @escaping (Bool) -> Void)
 }

--- a/KabuKitTests/Mock/MockGuide.swift
+++ b/KabuKitTests/Mock/MockGuide.swift
@@ -12,6 +12,9 @@ class MockGuide: Guide {
     var calledSecondToFirst: Bool = false
     
     var calledSecondToSecond: Bool = false
+
+    /// leaveを実行した際にrewindイベントが呼び出されたかどうかを保持します
+    var wasRunRewindHandler: Bool = false
     
     let tmpSecondScene: MockSecondScene = MockSecondScene()
 
@@ -39,6 +42,7 @@ class MockGuide: Guide {
             }) { (args) in
                 self.firstToSecond(args: args)
                 return {
+                    self.wasRunRewindHandler = true
                     self.reset()
                 }
             }

--- a/KabuKitTests/ScenarioTest.swift
+++ b/KabuKitTests/ScenarioTest.swift
@@ -55,7 +55,7 @@ class ScenarioTest: XCTestCase {
             }
         }
 
-        scenario.back { (completion) in
+        scenario.back(true) { (completion) in
 
         }
         XCTAssertFalse(isBeginCalled)

--- a/KabuKitTests/SceneSequenceTest.swift
+++ b/KabuKitTests/SceneSequenceTest.swift
@@ -89,11 +89,10 @@ class SceneSequenceTest: XCTestCase {
         self.wait(for: [asyncExpection!], timeout: 2.0)
     }
 
-
     /**
      Tests for leave(_ runTransition:)
      */
-    func leaveTestUtility(runTransition: Bool, wasRunRewindHandlerExpectation: Bool) -> Void {
+    func leaveTest(runTransition: Bool, wasRunRewindHandlerExpectation: Bool) -> Void {
         let request = MockScenarioRequest3()
         let asyncExpection: XCTestExpectation? = self.expectation(description: "wait")
 
@@ -117,11 +116,11 @@ class SceneSequenceTest: XCTestCase {
     }
 
     func test_leaveが引数trueで呼び出された場合にはrewindイベントが実行される() {
-        self.leaveTestUtility(runTransition: true, wasRunRewindHandlerExpectation: true)
+        self.leaveTest(runTransition: true, wasRunRewindHandlerExpectation: true)
     }
 
     func test_leaveが引数falseで呼び出された場合にはrewindイベントが実行されない() {
-        self.leaveTestUtility(runTransition: false, wasRunRewindHandlerExpectation: false)
+        self.leaveTest(runTransition: false, wasRunRewindHandlerExpectation: false)
     }
 
     func testPerformanceExample() {

--- a/KabuKitTests/SceneSequenceTest.swift
+++ b/KabuKitTests/SceneSequenceTest.swift
@@ -53,7 +53,7 @@ class SceneSequenceTest: XCTestCase {
             self.firstScene.send(request, { (completion) in
                 XCTAssertTrue(completion)
                 XCTAssertTrue(self.guide.calledFirstToSecond)
-                self.guide.tmpSecondScene.leave{(completion) in
+                self.guide.tmpSecondScene.leave(true) {(completion) in
                     XCTAssertFalse(self.guide.calledFirstToSecond)
                     asyncExpection?.fulfill()
                 }

--- a/KabuKitTests/SceneSequenceTest.swift
+++ b/KabuKitTests/SceneSequenceTest.swift
@@ -20,6 +20,9 @@ class SceneSequenceTest: XCTestCase {
         sequence = SceneSequence<Void, MockGuide>(guide)
 
         // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // rewindイベントが呼び出されたかどうかの状態を初期化
+        self.guide.wasRunRewindHandler = false
     }
     
     override func tearDown() {
@@ -53,7 +56,7 @@ class SceneSequenceTest: XCTestCase {
             self.firstScene.send(request, { (completion) in
                 XCTAssertTrue(completion)
                 XCTAssertTrue(self.guide.calledFirstToSecond)
-                self.guide.tmpSecondScene.leave(true) {(completion) in
+                self.guide.tmpSecondScene.leave() {(completion) in
                     XCTAssertFalse(self.guide.calledFirstToSecond)
                     asyncExpection?.fulfill()
                 }
@@ -63,7 +66,64 @@ class SceneSequenceTest: XCTestCase {
         self.wait(for: [asyncExpection!], timeout: 2.0)
 
     }
-    
+
+    /**
+     Tests for leave()
+     */
+    func test_leaveが引数無しで呼び出された場合にはrewindイベントが実行される() {
+        let request = MockScenarioRequest3()
+        let asyncExpection: XCTestExpectation? = self.expectation(description: "wait")
+
+        sequence?.startWith(stage, firstScene, ()) { (scene, stage) in
+            stage.setScene(scene: scene)
+            self.firstScene.send(request, { (completion) in
+                self.guide.tmpSecondScene.leave()
+
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                    XCTAssertTrue(self.guide.wasRunRewindHandler)
+                    asyncExpection?.fulfill()
+                }
+            })
+        }
+
+        self.wait(for: [asyncExpection!], timeout: 2.0)
+    }
+
+
+    /**
+     Tests for leave(_ runTransition:)
+     */
+    func leaveTestUtility(runTransition: Bool, wasRunRewindHandlerExpectation: Bool) -> Void {
+        let request = MockScenarioRequest3()
+        let asyncExpection: XCTestExpectation? = self.expectation(description: "wait")
+
+        sequence?.startWith(stage, firstScene, ()) { (scene, stage) in
+            stage.setScene(scene: scene)
+            self.firstScene.send(request, { (completion) in
+                self.guide.tmpSecondScene.leave(runTransition)
+
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                    if wasRunRewindHandlerExpectation {
+                        XCTAssertTrue(self.guide.wasRunRewindHandler)
+                    } else {
+                        XCTAssertFalse(self.guide.wasRunRewindHandler)
+                    }
+                    asyncExpection?.fulfill()
+                }
+            })
+        }
+
+        self.wait(for: [asyncExpection!], timeout: 2.0)
+    }
+
+    func test_leaveが引数trueで呼び出された場合にはrewindイベントが実行される() {
+        self.leaveTestUtility(runTransition: true, wasRunRewindHandlerExpectation: true)
+    }
+
+    func test_leaveが引数falseで呼び出された場合にはrewindイベントが実行されない() {
+        self.leaveTestUtility(runTransition: false, wasRunRewindHandlerExpectation: false)
+    }
+
     func testPerformanceExample() {
         // This is an example of a performance test case.
         self.measure {


### PR DESCRIPTION
__Updates__

- Add `rewind` call condition argument to KabuKit
- Add example usage to `Sample1AScene`

__Detail__

This PR modifies following features.

* Add argument to control invocation of `rewind` event.

With this modification, each caller (subclass of `Scene` ) will be able to choose to call `rewind` event or not when they call `leave` .

__Example__

In each subclass of `Scene` (which will be added/pushed to `UINavigationController` etc) :

```swift
override func viewDidDisappear(_ animated: Bool) {
    if self.isMovingFromParentViewController {
        leave(false)
    }
}
```

With this hook, KabuKit will remove this `Scene` from own `SceneContainer` without calling `rewind` event.