### PR TITLE
:hotfix: fix typo `current`

### DIFF
--- a/KabuKit/Classes/core/Swift/Scene.swift
+++ b/KabuKit/Classes/core/Swift/Scene.swift
@@ -88,7 +88,7 @@ public extension Scene where Self.ReturnValue == Void {
         leaveFromCurrent(returnValue: ())
     }
     
-    public func leaveFromCurrnt(runTransition: Bool) {
+    public func leaveFromCurrent(runTransition: Bool) {
         leaveFromCurrent(returnValue: (), runTransition: runTransition)
     }
     
@@ -96,7 +96,7 @@ public extension Scene where Self.ReturnValue == Void {
         leaveFromCurrent(returnValue: (), runTransition: true, completion)
     }
     
-    public func leaveFromCurrnt(runTransition: Bool, completion: @escaping (Bool) -> Void) -> Void {
+    public func leaveFromCurrent(runTransition: Bool, completion: @escaping (Bool) -> Void) -> Void {
         leaveFromCurrent(returnValue: (), runTransition: runTransition, completion)
     }
 }

--- a/KabuKitTests/SceneTest.swift
+++ b/KabuKitTests/SceneTest.swift
@@ -40,7 +40,7 @@ class SceneTest: XCTestCase {
         mockScreen.registerRewind { (arg) in
             isCalled = true
         }
-        mockScreen.leaveFromCurrnt(runTransition: false) { (result) in
+        mockScreen.leaveFromCurrent(runTransition: false) { (result) in
             XCTAssertTrue(result)
         }
         XCTAssertFalse(isCalled)


### PR DESCRIPTION
**Detail**
- fixed `currnt` -> `current`