### PR TITLE
Change Scene's ReturnValue associetedType

### DIFF
--- a/KabuKit/Classes/core/Swift/Scene.swift
+++ b/KabuKit/Classes/core/Swift/Scene.swift
@@ -15,7 +15,7 @@ public protocol Scene : class, Screen {
 
 public extension Scene {
     
-    typealias Rewind = ((ReturnValue?) -> Void)
+    typealias Rewind = ((ReturnValue) -> Void)
     
     internal var scenario: TransitionProcedure? {
         return procedureByScene[ScreenHashWrapper(self)]
@@ -29,7 +29,7 @@ public extension Scene {
         return contextByScreen[ScreenHashWrapper(self)] as! Self.Context
     }
     
-    var onLeave: ((ReturnValue?) -> Void)? {
+    var onLeave: ((ReturnValue) -> Void)? {
         return onLeaveByScene[ScreenHashWrapper(self)] as? Rewind
     }
     
@@ -37,7 +37,7 @@ public extension Scene {
         contextByScreen[ScreenHashWrapper(self)] = value as? Self.Context
     }
     
-    internal func registerRewind(f: @escaping (ReturnValue?) -> Void) {
+    internal func registerRewind(f: @escaping (ReturnValue) -> Void) {
         rewindByScene[ScreenHashWrapper(self)] = f
     }
     
@@ -45,7 +45,7 @@ public extension Scene {
         procedureByScene[ScreenHashWrapper(self)] = scenario
     }
     
-    internal func registerOnLeave(f: @escaping (ReturnValue?) -> Void) {
+    internal func registerOnLeave(f: @escaping (ReturnValue) -> Void) {
         onLeaveByScene[ScreenHashWrapper(self)] = f
     }
     
@@ -57,15 +57,15 @@ public extension Scene {
         self.scenario?.start(atRequestOf: request, completion)
     }
     
-    public func leaveFromCurrent(returnValue: ReturnValue?) {
+    public func leaveFromCurrent(returnValue: ReturnValue) {
         self.leaveFromCurrent(returnValue: returnValue, runTransition: true)
     }
     
-    public func leaveFromCurrent(returnValue: ReturnValue?, runTransition: Bool) {
+    public func leaveFromCurrent(returnValue: ReturnValue, runTransition: Bool) {
         self.leaveFromCurrent(returnValue: returnValue, runTransition: runTransition, { (Bool) in })
     }
     
-    public func leaveFromCurrent(returnValue: ReturnValue?, runTransition: Bool, _ completion: @escaping (Bool) -> Void) -> Void {
+    public func leaveFromCurrent(returnValue: ReturnValue, runTransition: Bool, _ completion: @escaping (Bool) -> Void) -> Void {
         guard let rewindMethod = rewind else {
             completion(false)
             return

--- a/KabuKit/Classes/core/Swift/SceneCollection.swift
+++ b/KabuKit/Classes/core/Swift/SceneCollection.swift
@@ -29,7 +29,7 @@ class SceneCollection<Stage> {
     func add<SceneType: Scene>(_ newScene: SceneType,
              with context: SceneType.Context,
              transition: (Stage, SceneType, Screen?) -> (() -> Void)?,
-             callbackOf onPop: ((SceneType.ReturnValue?) -> Void)?) {
+             callbackOf onPop: ((SceneType.ReturnValue) -> Void)?) {
         
         
         let scenario = operation.resolve(from: newScene)

--- a/KabuKit/Classes/core/Swift/SceneSequence.swift
+++ b/KabuKit/Classes/core/Swift/SceneSequence.swift
@@ -80,10 +80,6 @@ public class SceneSequence<FirstScene: Scene, Guide: SequenceGuide> : SceneColle
         }
     }
     
-    deinit {
-        self.leaveFromCurrent(returnValue: nil)
-    }
-    
     /**
      SceneSequenceを生成する
     

--- a/KabuKit/Classes/core/Swift/TransitionRequest.swift
+++ b/KabuKit/Classes/core/Swift/TransitionRequest.swift
@@ -3,15 +3,13 @@ import Foundation
 open class TransitionRequest<Context, ReturnValue> {
     
     public let context: Context
+    public let callback: (ReturnValue) -> Void
     
-    public let callback: (ReturnValue?) -> Void
-    
-    public init(_ context: Context, whenRewind: @escaping (ReturnValue?) -> Void) {
+    public required init(_ context: Context, whenRewind: @escaping (ReturnValue) -> Void) {
         self.context = context
         self.callback = whenRewind
     }
 }
-
 
 public extension TransitionRequest where ReturnValue == Void {
 
@@ -24,7 +22,7 @@ public extension TransitionRequest where ReturnValue == Void {
 
 public extension TransitionRequest where Context == Void {
     
-    public convenience init(_ rewind: @escaping (ReturnValue?) -> Void) {
+    public convenience init(_ rewind: @escaping (ReturnValue) -> Void) {
         self.init((), whenRewind: rewind)
     }
 }


### PR DESCRIPTION
**Detail**
This commit change `Scene`'s ReturnValue gained through `rewind method` was Optional to Non Optional.
Because, it is inconvenient because it is necessary to check nil when receiving RetuneValue.

**Breaking Change**
initialize `TransitionRequest` have to change this.

- before

```swift
let request = HogeRequest() { ret in // result is optional
   guard let result = result else { return }
   // process using result
}
```
- after

```swift
let request = HogeRequest() { ret in // result is non-optional
   // process using result
}
```