### PR TITLE
:hammer: SceneSequenceBuilder add new builder interface

### DIFF
--- a/Example/Sample1/AppDelegate.swift
+++ b/Example/Sample1/AppDelegate.swift
@@ -20,7 +20,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         
-
         // Override point for customization after application launch.
         self.window = UIWindow(frame: UIScreen.main.bounds)
         self.window!.rootViewController = UIViewController()
@@ -30,20 +29,26 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let rule = SampleSequenceRule()
         let builder = SceneSequence.builder(scene: scene, guide: rule)
             .setup(UINavigationController(rootViewController: UIViewController()), with: false)
-        
-        sequence = builder.build(onInit: { (stage, scene) in
+
+        sequence = builder.build {
+            let stage = $0.stage
+            let scene = $0.firstScene
             stage.isNavigationBarHidden = true
             stage.pushViewController(scene, animated: true)
-        }, onActive: { (stage, screens) in
-            self.window?.rootViewController?.addChildViewController(stage)
-            self.window?.rootViewController?.view.addSubview(stage.view)
-        }, onSuspend: { (stage, screens) in
-            stage.view.removeFromSuperview()
-            stage.removeFromParentViewController()
-        })
 
+            $0.callbacks.onActivate { (screens) in
+                self.window?.rootViewController?.addChildViewController(stage)
+                self.window?.rootViewController?.view.addSubview(stage.view)
+            }
+
+            $0.callbacks.onSuspend { (screens) in
+                stage.view.removeFromSuperview()
+                stage.removeFromParentViewController()
+            }
+
+            return {}
+        }
         sequence?.activate()
-
         return true
     }
 

--- a/KabuKit/Classes/core/Swift/SceneSequenceBuilder.swift
+++ b/KabuKit/Classes/core/Swift/SceneSequenceBuilder.swift
@@ -47,6 +47,15 @@ public class SceneSequenceBuilder<FirstScene: Scene, Guide: SequenceGuide, Conte
 
 public extension SceneSequenceBuilder where Context == Buildable, Stage == Buildable {
     
+    public typealias Subscriber = SceneSequence<FirstScene, Guide>.SequenceStatusSubscriber
+    
+    public typealias BuildArgument = (
+        stage: Guide.Stage,
+        firstScene: FirstScene,
+        callbacks: Subscriber
+    )
+    
+    @available(*, deprecated, message: "this method will be deleted at version 0.5.0")
     public func build(onInit: @escaping (Guide.Stage, FirstScene) -> Void,
                       onActive: ((Guide.Stage, [Screen]) -> Void)? = nil,
                       onSuspend: ((Guide.Stage, [Screen]) -> Void)? = nil,
@@ -59,7 +68,8 @@ public extension SceneSequenceBuilder where Context == Buildable, Stage == Build
                      onSuspend: onSuspend,
                      onLeave: onLeave)
     }
-    
+
+    @available(*, deprecated, message: "this method will be deleted at version 0.5.0")
     public func build(onInitWithRewind: @escaping (Guide.Stage, FirstScene) -> (() -> Void)?,
                       onActive: ((Guide.Stage, [Screen]) -> Void)? = nil,
                       onSuspend: ((Guide.Stage, [Screen]) -> Void)? = nil,
@@ -76,5 +86,21 @@ public extension SceneSequenceBuilder where Context == Buildable, Stage == Build
                              onActive: onActive,
                              onSuspend: onSuspend,
                              onLeave: onLeave)
+    }
+
+    public func build(initializer: @escaping (BuildArgument) -> (() -> Void)?) -> SceneSequence<FirstScene, Guide> {
+        guard let stage = self.stage else { fatalError() }
+        guard let context = self.context else { fatalError() }
+        let subscriber = SceneSequence<FirstScene, Guide>.SequenceStatusSubscriber()
+        let onStart = { (stage: Guide.Stage, scene: FirstScene) -> (() -> Void)? in
+            return initializer((stage, scene, subscriber))
+        }
+
+        return SceneSequence(stage: stage,
+                             scene: firstScene,
+                             guide: guide,
+                             context: context,
+                             subscriber: subscriber,
+                             onStart: onStart)
     }
 }


### PR DESCRIPTION
**Abstruct**
* SceneSequenceBuilder's Build method change to this
  before
  ```swift
  sequence = builder.build { (stage, scene) in
    stage.pushViewController(scene, animated: true)
  }, onActive: { (stage, screens) in
    self.window?.rootViewController?.addChildViewController(stage)
    self.window?.rootViewController?.view.addSubview(stage.view)
  }, onSuspend: { (stage, screens) in
    stage.view.removeFromSuperview()
    stage.removeFromParentViewController()
  })
  ```
  after
  ```swift
   sequence = builder.build {
      let stage = $0.stage
      let scene = $0.firstScene
      stage.pushViewController(scene, animated: true)

      $0.execute.onActivate { (screens) in
         self.window?.rootViewController?.addChildViewController(stage)
         self.window?.rootViewController?.view.addSubview(stage.view)
      }

      $0.execute.onSuspend { (screens) in
          stage.view.removeFromSuperview()
          stage.removeFromParentViewController()
       }
       return {
         // rewind process
       }
     }
  ```